### PR TITLE
Better password advice

### DIFF
--- a/gui/app/templates/components/documize-setup.hbs
+++ b/gui/app/templates/components/documize-setup.hbs
@@ -25,7 +25,7 @@
 		<div class="form-group">
 			<label for="adminPassword">Password</label>
 			{{input id="adminPassword" type="password" value=model.password class=(if hasEmptyPasswordError 'form-control is-invalid' 'form-control')}}
-			<small class="form-text text-muted">Something you can remember without writing it down</small>
+			<small class="form-text text-muted">Pick something strong and unique that you don't use anywhere else</small>
 		</div>
 		<button type="submit" class="btn btn-success mt-5" {{action 'save'}}>{{buttonLabel}}</button>
 	</form>


### PR DESCRIPTION
The password advice on the setup screen is terrible! Writing down passwords (in a secure password manager) is always better than trying to pick something you can remember.