### PR TITLE
Ignore PostGIS when determining if PostgreSQL is empty

### DIFF
--- a/edition/storage/postgresql.go
+++ b/edition/storage/postgresql.go
@@ -244,7 +244,7 @@ func (p PostgreSQLProvider) QueryGetDatabaseVersionLegacy() string {
 func (p PostgreSQLProvider) QueryTableList() string {
 	return fmt.Sprintf(`select table_name
         FROM information_schema.tables
-        WHERE table_type='BASE TABLE' AND table_schema NOT IN ('pg_catalog', 'information_schema') AND table_catalog='%s'`, p.DatabaseName())
+        WHERE table_type='BASE TABLE' AND table_schema NOT IN ('pg_catalog', 'information_schema') AND table_name != 'spatial_ref_sys' AND table_catalog='%s'`, p.DatabaseName())
 }
 
 // QueryDateInterval returns provider specific interval style


### PR DESCRIPTION
If the PostGIS extension is installed in PostgreSQL the 'spatial_ref_sys' will automatically have been installed in the public schema. Documize would see this table and incorrectly assume it shouldn't enter setup mode.

Since PostGIS is quite a popular extension for PostgreSQL people who use their PostgreSQL database for multiple applications can potentially run in to this (like I did). This is most likely to occur when a schema per application is used. In PostgreSQL a schema (ie. `CREATE SCHEMA foo`) is the MySQL equivalent of a database (ie. `CREATE DATABASE foo`). 

Using a PostgreSQL database (ie. using PostgreSQL's `createdb` from the CLI) creates an almost entirely separate PostgreSQL instance which means it needs it's own backup infrastructure (pgbarman, etc.), it's how replication infrastructure (stolon, etc.), etc. which makes it not really suitable for multi tenant.