### PR TITLE
Render HTML in Markdown during previews as well

### DIFF
--- a/gui/app/components/section/markdown/type-editor.js
+++ b/gui/app/components/section/markdown/type-editor.js
@@ -91,7 +91,7 @@ export default Component.extend({
 					this.attachEditor();
 				} else {
 					this.set('pageBody',this.getBody());
-					let md = window.markdownit({ linkify: true });
+					let md = window.markdownit({ linkify: true, html: true });
 					let result = md.render(this.getBody());
 
 					this.set('pagePreview', result);


### PR DESCRIPTION
When having e.g. a markdown-based section in a document where you
reference another document, a HTML-link is generated. However when
previewing changes, the raw HTML is shown.

With setting `html: true` in the configuration for `markdownit`[1],
HTML is detected and properly parsed (Also markup tags such as `<h1>`
are rendered properly just like when using `blackfriday` to request a rendered
section).

Regarding probably harmful side-effects: setting e.g. `<style>* { display:
none !important; }</style>` causes a white page with `markdownit` as
well as with `blackfriday`. `<script>` tags aren't affected since
`handlebars` mostly breaks with `<script>` tags within variables that
are substituted using `{{{var}}}` into the DOM[3].

Please note that I didn't commit the modifications in `embed/bindata.go`
as it seemed to me after looking at the history that those updates are
only done when preparing a release.

[1] https://github.com/markdown-it/markdown-it/blob/1ad3aec2041cd2defa7e299543cc1e42184b680d/lib/presets/default.js#L6-L9
[2] https://github.com/documize/blackfriday/blob/master/markdown.go#L105-L146
[3] https://github.com/wycats/handlebars.js/issues/531