### PR TITLE
Fixed and updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.12-alpine as builder
+FROM golang:1.15-alpine as builder
 COPY . /go/src/github.com/documize/community
-RUN cd /go/src/github.com/documize/community
+WORKDIR /go/src/github.com/documize/community
 RUN env GOOS=linux GOARCH=amd64 GODEBUG=tls13=1 go build -mod=vendor -o bin/documize-community-linux-amd64 ./edition/community.go
 
 # build release image


### PR DESCRIPTION
The old dockerfile did not run and printed the following error:

```
Step 4/9 : RUN env GOOS=linux GOARCH=amd64 GODEBUG=tls13=1 go build -mod=vendor -o bin/documize-community-linux-amd64 ./edition/community.go
 ---> Running in 5aa2130adfd9
build flag -mod=vendor only valid when using modules
```

A little digging brought me to [this issue](https://github.com/golang/go/issues/29665), apparently this flag is either missing or bugged in golang 1.12.

So I updated the images base from golang 1.12 to 1.15. I also changed a `RUN cd` directive to `WORKDIR` to work around a second issue with relative paths in the command:
```
stat ./edition/community.go: no such file or directory
```