### PR TITLE
document/wysiwig: no margin for sublists

### DIFF
--- a/gui/app/styles/core/view/document/wysiwyg.scss
+++ b/gui/app/styles/core/view/document/wysiwyg.scss
@@ -39,6 +39,11 @@
 		line-height: 1.8rem;
 	}
 
+	ol ol, ul ul {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+
 	ol {
 		li {
 			// list-style-type: decimal;


### PR DESCRIPTION
When having a list with sublists in a `markdown` section like this

  * top-level
  * another one
    * sub-elem 1
    * sub-elem 2

then documize will create a margin of 15px before and after the sublist
which is rather unintuitive as this will create the wrong impression
that these bullet-points have no relation to the parent one even though
this is the most common semantic reason for sublists.

This patch removes the margin at the top and bottom for those kinds of
sublists.