### PR TITLE
Modernize Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,4 @@
 bin
 .idea
 selfcert
-gui
+gui/dist-prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,30 @@
-FROM golang:1.15-alpine as builder
-COPY . /go/src/github.com/documize/community
+FROM node:lts-alpine as frontbuilder
+WORKDIR /go/src/github.com/documize/community/gui
+COPY ./gui /go/src/github.com/documize/community/gui
+RUN npm --network-timeout=100000 install
+RUN npm run build -- --environment=production --output-path dist-prod --suppress-sizes true
+
+FROM golang:1.17-alpine as builder
 WORKDIR /go/src/github.com/documize/community
-RUN env GOOS=linux GOARCH=amd64 GODEBUG=tls13=1 go build -mod=vendor -o bin/documize-community-linux-amd64 ./edition/community.go
+COPY . /go/src/github.com/documize/community
+COPY --from=frontbuilder /go/src/github.com/documize/community/gui/dist-prod/assets /go/src/github.com/documize/community/edition/static/public/assets
+COPY --from=frontbuilder /go/src/github.com/documize/community/gui/dist-prod/codemirror /go/src/github.com/documize/community/edition/static/public/codemirror
+COPY --from=frontbuilder /go/src/github.com/documize/community/gui/dist-prod/prism /go/src/github.com/documize/community/edition/static/public/prism
+COPY --from=frontbuilder /go/src/github.com/documize/community/gui/dist-prod/sections /go/src/github.com/documize/community/edition/static/public/sections
+COPY --from=frontbuilder /go/src/github.com/documize/community/gui/dist-prod/tinymce /go/src/github.com/documize/community/edition/static/public/tinymce
+COPY --from=frontbuilder /go/src/github.com/documize/community/gui/dist-prod/pdfjs /go/src/github.com/documize/community/edition/static/public/pdfjs
+COPY --from=frontbuilder /go/src/github.com/documize/community/gui/dist-prod/*.* /go/src/github.com/documize/community/edition/static/
+COPY domain/mail/*.html /go/src/github.com/documize/community/edition/static/mail/
+COPY core/database/templates/*.html /go/src/github.com/documize/community/edition/static/
+COPY core/database/scripts/mysql/*.sql /go/src/github.com/documize/community/edition/static/scripts/mysql/
+COPY core/database/scripts/postgresql/*.sql /go/src/github.com/documize/community/edition/static/scripts/postgresql/
+COPY core/database/scripts/sqlserver/*.sql /go/src/github.com/documize/community/edition/static/scripts/sqlserver/
+COPY domain/onboard/*.json /go/src/github.com/documize/community/edition/static/onboard/
+RUN env GODEBUG=tls13=1 go build -mod=vendor -o bin/documize-community ./edition/community.go
 
 # build release image
-FROM alpine:3.10
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
-COPY --from=builder /go/src/github.com/documize/community/bin/documize-community-linux-amd64 /documize
+FROM alpine:3.14
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /go/src/github.com/documize/community/bin/documize-community /documize
 EXPOSE 5001
 ENTRYPOINT [ "/documize" ]


### PR DESCRIPTION
Hi,

The current `Dockerfile` fails with the following error:

```
# docker build .
Sending build context to Docker daemon   24.3MB
Step 1/9 : FROM golang:1.15-alpine as builder
 ---> 0f3320450768
Step 2/9 : COPY . /go/src/github.com/documize/community
 ---> 4d6ac3795f01
Step 3/9 : WORKDIR /go/src/github.com/documize/community
 ---> Running in a207f6295bfc
Removing intermediate container a207f6295bfc
 ---> 83ef0d449820
Step 4/9 : RUN env GOOS=linux GOARCH=arm64 GODEBUG=tls13=1 go build -mod=vendor -o bin/documize-community-linux-arm64 ./edition/community.go
 ---> Running in b16fb97e3329
edition/community.go:16:2: cannot find package "." in:
        /go/src/github.com/documize/community/vendor/embed
core/asset/assets.go:7:2: cannot find package "." in:
        /go/src/github.com/documize/community/vendor/io/fs
The command '/bin/sh -c env GOOS=linux GOARCH=arm64 GODEBUG=tls13=1 go build -mod=vendor -o bin/documize-community-linux-arm64 ./edition/community.go' returned a non-zero code: 1
```

This is due to the fact that the `Dockerfile` requires Go 1.15 instead of Go 1.16 at least.

After updating the go version, there is still an error:

```
$ docker build .
Sending build context to Docker daemon   24.3MB
Step 1/9 : FROM golang:1.16-alpine as builder
 ---> 9e9fffa30629
Step 2/9 : COPY . /go/src/github.com/documize/community
 ---> Using cache
 ---> f3ff239af53a
Step 3/9 : WORKDIR /go/src/github.com/documize/community
 ---> Using cache
 ---> 586589820732
Step 4/9 : RUN env GOOS=linux GOARCH=arm64 GODEBUG=tls13=1 go build -mod=vendor -o bin/documize-community-linux-arm64 ./edition/community.go
 ---> Running in 834300cfb7e8
edition/community.go:29:12: pattern static/*: no matching files found
The command '/bin/sh -c env GOOS=linux GOARCH=arm64 GODEBUG=tls13=1 go build -mod=vendor -o bin/documize-community-linux-arm64 ./edition/community.go' returned a non-zero code: 1
```

As `bindata.go` is no more provided, we need to build the front assets in the `Dockerfile`.

This PR is a refresh proposal, including:

- frontend build (`--network-timeout` option is for slow disk bandwidth devices like Raspberry Pi),
- updating alpine from 3.10 (out-of-date since May 2021),
- without `GOARCH` defined in order to build images for other architectures (tested on amd64 and arm64).