### PR TITLE
Dockerfile: Force node 16 + update go and alpine tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:lts-alpine as frontbuilder
+FROM node:16-alpine as frontbuilder
 WORKDIR /go/src/github.com/documize/community/gui
 COPY ./gui /go/src/github.com/documize/community/gui
 RUN npm --network-timeout=100000 install
 RUN npm run build -- --environment=production --output-path dist-prod --suppress-sizes true
 
-FROM golang:1.17-alpine as builder
+FROM golang:1.19-alpine as builder
 WORKDIR /go/src/github.com/documize/community
 COPY . /go/src/github.com/documize/community
 COPY --from=frontbuilder /go/src/github.com/documize/community/gui/dist-prod/assets /go/src/github.com/documize/community/edition/static/public/assets
@@ -25,7 +25,7 @@ COPY domain/onboard/*.json /go/src/github.com/documize/community/edition/static/
 RUN env GODEBUG=tls13=1 go build -mod=vendor -o bin/documize-community ./edition/community.go
 
 # build release image
-FROM alpine:3.14
+FROM alpine:3.16
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/src/github.com/documize/community/bin/documize-community /documize
 EXPOSE 5001


### PR DESCRIPTION
Hi!

Here is a commit that updates the Dockerfile.

First, when building with the current LTS release of node, an error occurs:
```
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/go/src/github.com/documize/community/gui/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/go/src/github.com/documize/community/gui/node_modules/webpack/lib/NormalModule.js:417:16)
    at /go/src/github.com/documize/community/gui/node_modules/webpack/lib/NormalModule.js:460:10
    at /go/src/github.com/documize/community/gui/node_modules/webpack/lib/NormalModule.js:358:12
    at /go/src/github.com/documize/community/gui/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/go/src/github.com/documize/community/gui/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at Array.<anonymous> (/go/src/github.com/documize/community/gui/node_modules/loader-runner/lib/LoaderRunner.js:205:4)
    at Storage.finished (/go/src/github.com/documize/community/gui/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:55:16)
    at /go/src/github.com/documize/community/gui/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:91:9
    at /go/src/github.com/documize/community/gui/node_modules/graceful-fs/graceful-fs.js:123:16
    at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.12.1
The command '/bin/sh -c npm run build -- --environment=production --output-path dist-prod --suppress-sizes true' returned a non-zero code: 1
```

It's not the case with node 16, the previous LTS, so I changed the tag to point to the 16 release.

Secondly, I update the Go and Alpine tags to keep them up-to-date (moreover the [project's requirements](https://github.com/documize/community#technology-stack) indicates Go 19, this is now in sync with the Dockerfile).