### PR TITLE
Updated docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
 
   app:
     image: debian:latest
-    command: /bin/sh -c "apt-get -qq update && apt-get -qq install -y wget && wget https://community-downloads.s3.us-east-2.amazonaws.com/documize-community-plus-linux-amd64 && chmod 777 ./documize-community-plus-linux-amd64 && ./documize-community-plus-linux-amd64"
+    command: /bin/sh -c "arch=$(dpkg --print-architecture) && apt-get -qq update && apt-get -qq install -y wget && wget https://community-downloads.s3.us-east-2.amazonaws.com/documize-community-plus-linux-${arch} && chmod 777 ./documize-community-plus-linux-${arch} && ./documize-community-plus-linux-${arch}"
     depends_on:
       - db
     ports:


### PR DESCRIPTION
Updated `docker-compose.yaml` to read the correct arch from device so arm64 devices can run Documize as well